### PR TITLE
Handled builds that are not associated to polled changes

### DIFF
--- a/src/components/DNEGridChange/DNEGridChange.tsx
+++ b/src/components/DNEGridChange/DNEGridChange.tsx
@@ -13,6 +13,44 @@ type ChangeDetailsProps = {
   setShowDetails: (show: boolean) => void;
 }
 
+type ChangeDetailsPropsNotFound = {
+  changeid: string;
+  timestamp: bigint;
+}
+
+const popoverWithText = (id: string, text: string) => {
+    return (
+      <Popover id={"bb-popover-change-details-" + id}>
+        <Popover.Content>
+          {text}
+        </Popover.Content>
+      </Popover>
+    );
+  }
+
+export const DNEGridChangeNotFound = ({changeid, timestamp}: ChangeDetailsPropsNotFound) => {
+    const now = useCurrentTime();
+    const content = (
+    <>
+      <OverlayTrigger placement="top" overlay={popoverWithText("comments-" + changeid, "No Change Found")}>
+        <b className="dne-changedetails-revision">{changeid}</b>
+      </OverlayTrigger>
+      <OverlayTrigger
+        placement="top"
+        overlay={popoverWithText("date-" + changeid, dateFormat(timestamp))}
+      >
+        <span><br/>{durationFromNowFormat(timestamp, now)}</span>
+      </OverlayTrigger>
+    </>
+    );
+
+    return (
+    <div className="dne-changedetails">
+        {content}
+    </div>
+    );
+}
+
 export const DNEGridChange = ({change, showDetails, setShowDetails}: ChangeDetailsProps) => {
   const now = useCurrentTime();
   const [showProps, setShowProps] = useState(false);
@@ -84,16 +122,6 @@ export const DNEGridChange = ({change, showDetails, setShowDetails}: ChangeDetai
   );
 
   const [changeAuthorName, changeEmail] = parseChangeAuthorNameAndEmail(change.author);
-
-  const popoverWithText = (id: string, text: string) => {
-    return (
-      <Popover id={"bb-popover-change-details-" + id}>
-        <Popover.Content>
-          {text}
-        </Popover.Content>
-      </Popover>
-    );
-  }
 
   const content = (
     <>

--- a/src/views/GridView/DNEGridView.tsx
+++ b/src/views/GridView/DNEGridView.tsx
@@ -3,7 +3,7 @@ import './DNEGridView.scss';
 import {ObservableMap, observable} from "mobx";
 import {observer, useLocalObservable} from "mobx-react";
 import {Link, useSearchParams} from "react-router-dom";
-import {Form} from "react-bootstrap";
+import {Form, OverlayTrigger, Popover} from "react-bootstrap";
 import {
   Builder,
   Build,
@@ -18,6 +18,7 @@ import {
   Buildrequest,
 } from "buildbot-data-js";
 import {
+  dateFormat,
   LoadingIndicator,
   BuildLinkWithSummaryTooltip
 } from "buildbot-ui";
@@ -27,6 +28,7 @@ import {getConfig, DNEConfig, DNEView} from "../../utils/Config";
 import {getRelatedOfFilteredDataMultiCollection} from "../../utils/DataMultiCollectionUtils";
 import {useState} from "react";
 import {DNEGridChange} from "../../components/DNEGridChange/DNEGridChange";
+import {DNEGridChangeNotFound} from "../../components/DNEGridChange/DNEGridChange";
 
 
 function getViewSelectForm(config: DNEConfig, defaultFetchLimit: number) {
@@ -394,17 +396,20 @@ export const DNEGridView = observer(() => {
     // then keep only last X changes
     .splice(buildFetchLimit);
 
-  const body = buildsPerChange.map(({change, builds}) => {
+  const body = buildsPerChange.map(({changeid, change, builds}) => {
     return (
     <tr>
       <td>
         {
-          change
+          change // The change has been properly polled, pull from the polled change info
           ? <DNEGridChange change={change}
               showDetails={changeIsExpandedByChangeId.get(change.changeid) ?? false}
               setShowDetails={(show: boolean) => changeIsExpandedByChangeId.set(change.changeid, show)}
             />
-          : "ChangeNotFound"
+          : changeid.length !=0 && builds.length != 0  // The change wasn't polled, pull what we can from earliest build
+                  ? <DNEGridChangeNotFound changeid={changeid}
+                                           timestamp={builds[0].started_at}/>
+                  : "ChangeNotFound"  // Last resort, we just don't what this change is
         }
       </td>
       {


### PR DESCRIPTION
It sometimes happen that some submits/commits are not polled properly, just try to handle those cases.
Display basic info (rev + date) when possible.
Tells that there is no change to be found when hovering info.

I think we want to broaden what we poll to minimize the issue though.

Here is an example (left uses pr, right is vanilla)
![image](https://github.com/dontnod/DNE-Buildbot-React-grid-view-plugin/assets/20304337/ab557759-9de6-49dc-8719-bfa32929e5f7)
